### PR TITLE
Feat: Create AutoJumpResetter mod

### DIFF
--- a/src/main/java/com/user/autojumpresetter/AttackEventHandler.java
+++ b/src/main/java/com/user/autojumpresetter/AttackEventHandler.java
@@ -26,7 +26,7 @@ public class AttackEventHandler {
         }
 
         // Condition 2: The damage source is another player
-        if (!event.source.isPlayerDamage()) {
+        if (!(event.source.getTrueSource() instanceof EntityPlayer)) {
             return;
         }
 

--- a/src/main/java/com/user/autojumpresetter/AttackEventHandler.java
+++ b/src/main/java/com/user/autojumpresetter/AttackEventHandler.java
@@ -1,0 +1,58 @@
+package com.user.autojumpresetter;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class AttackEventHandler {
+
+    private long lastJumpTime = 0;
+    private static final long COOLDOWN = 1000; // 1 second
+
+    @SubscribeEvent
+    public void onLivingHurt(LivingHurtEvent event) {
+        // Condition 1: The entity being hurt is the player
+        if (!(event.entityLiving instanceof EntityPlayer)) {
+            return;
+        }
+
+        EntityPlayer player = (EntityPlayer) event.entityLiving;
+        Minecraft mc = Minecraft.getMinecraft();
+
+        // Ensure we are in the client world and it's the main player
+        if (player != mc.thePlayer) {
+            return;
+        }
+
+        // Condition 2: The damage source is another player
+        if (!event.source.isPlayerDamage()) {
+            return;
+        }
+
+        // Condition 3: The player is on the ground
+        if (!player.onGround) {
+            return;
+        }
+
+        // Condition 4: The player is not manually jumping
+        if (mc.gameSettings.keyBindJump.isKeyDown()) {
+            return;
+        }
+
+        // Condition 5: The player is not using an item (e.g., blocking, eating)
+        if (player.isUsingItem()) {
+            return;
+        }
+
+        // Cooldown check
+        long currentTime = System.currentTimeMillis();
+        if (currentTime - lastJumpTime < COOLDOWN) {
+            return;
+        }
+
+        // If all conditions are met, perform the jump
+        player.jump();
+        lastJumpTime = currentTime;
+    }
+}

--- a/src/main/java/com/user/autojumpresetter/AttackEventHandler.java
+++ b/src/main/java/com/user/autojumpresetter/AttackEventHandler.java
@@ -26,7 +26,7 @@ public class AttackEventHandler {
         }
 
         // Condition 2: The damage source is another player
-        if (!(event.source.getTrueSource() instanceof EntityPlayer)) {
+        if (!(event.source.getEntity() instanceof EntityPlayer)) {
             return;
         }
 

--- a/src/main/java/com/user/autojumpresetter/AutoJumpResetter.java
+++ b/src/main/java/com/user/autojumpresetter/AutoJumpResetter.java
@@ -1,0 +1,18 @@
+package com.user.autojumpresetter;
+
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+@Mod(modid = AutoJumpResetter.MODID, version = AutoJumpResetter.VERSION)
+public class AutoJumpResetter {
+    public static final String MODID = "autojumpresetter";
+    public static final String VERSION = "1.0";
+
+    @EventHandler
+    public void init(FMLInitializationEvent event) {
+        // Register the event handler
+        MinecraftForge.EVENT_BUS.register(new AttackEventHandler());
+    }
+}


### PR DESCRIPTION
This commit introduces the AutoJumpResetter mod for Minecraft 1.8.9 using the Forge API.

The mod automatically simulates a player jump upon receiving a melee attack from another player. This action is triggered only under specific conditions:
- The player is on the ground.
- The player is not already holding the jump key.
- The player is not using an item (e.g., blocking or eating).

A 1-second cooldown is implemented to prevent spamming and ensure controlled activation. The core logic is handled within the `LivingHurtEvent` to ensure precise timing.